### PR TITLE
Add Calendar to ScrollView

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -130,36 +130,6 @@ export default function FlowCalendar() {
       <TouchableWithoutFeedback onPress={dismissKeyboard}>
         <KeyboardAvoidingView style={{ flex: 1 }}>
           <SafeAreaView style={styles.container}>
-            <View
-              style={{ backgroundColor: theme.colors.background, padding: 4 }}
-            >
-              <Calendar
-                maxDate={today}
-                markedDates={{ ...storedDatesState }}
-                enableSwipeMonths={true}
-                onDayPress={(day: { dateString: string }) =>
-                  setDate(day.dateString)
-                }
-                theme={{
-                  calendarBackground: theme.colors.background,
-                  textSectionTitleColor: theme.colors.secondary,
-                  selectedDayBackgroundColor: theme.colors.primary,
-                  selectedDayTextColor: theme.colors.onPrimary,
-                  todayTextColor: theme.colors.primary,
-                  dayTextColor: theme.colors.onBackground,
-                  textDisabledColor: theme.colors.surfaceVariant,
-                  arrowColor: theme.colors.primary,
-                  monthTextColor: theme.colors.primary,
-                  textDayFontFamily: "monospace",
-                  textMonthFontFamily: "monospace",
-                  textDayHeaderFontFamily: "monospace",
-                  textDayFontSize: 16,
-                  textMonthFontSize: 16,
-                  textDayHeaderFontSize: 16,
-                }}
-              />
-              <Divider />
-            </View>
             <ScrollView
               contentContainerStyle={{
                 flexGrow: 1,
@@ -167,6 +137,36 @@ export default function FlowCalendar() {
               }}
               automaticallyAdjustKeyboardInsets={true}
             >
+              <View
+                style={{ backgroundColor: theme.colors.background, padding: 4 }}
+              >
+                <Calendar
+                  maxDate={today}
+                  markedDates={{ ...storedDatesState }}
+                  enableSwipeMonths={true}
+                  onDayPress={(day: { dateString: string }) =>
+                    setDate(day.dateString)
+                  }
+                  theme={{
+                    calendarBackground: theme.colors.background,
+                    textSectionTitleColor: theme.colors.secondary,
+                    selectedDayBackgroundColor: theme.colors.primary,
+                    selectedDayTextColor: theme.colors.onPrimary,
+                    todayTextColor: theme.colors.primary,
+                    dayTextColor: theme.colors.onBackground,
+                    textDisabledColor: theme.colors.surfaceVariant,
+                    arrowColor: theme.colors.primary,
+                    monthTextColor: theme.colors.primary,
+                    textDayFontFamily: "monospace",
+                    textMonthFontFamily: "monospace",
+                    textDayHeaderFontFamily: "monospace",
+                    textDayFontSize: 16,
+                    textMonthFontSize: 16,
+                    textDayHeaderFontSize: 16,
+                  }}
+                />
+                <Divider />
+              </View>
               <View>{date && <DayView />}</View>
             </ScrollView>
           </SafeAreaView>


### PR DESCRIPTION
It's hard to see things in the `DayView` component on some smaller-sized screens, so I've added the calendar to the `ScrollView` so that it will now scroll along with the `DayView` component. I initially [looked into](https://github.com/adulbrich/PrivyPeriod/issues/40) using React Native Calendar's ExpandableCalendar, but it had a lot of issues that haven't been addressed that made it a bad option for us for the time being. 